### PR TITLE
Fix format bug and add options

### DIFF
--- a/src/RtLopez/Decimal.php
+++ b/src/RtLopez/Decimal.php
@@ -9,6 +9,8 @@ abstract class Decimal
 {
   private static $defaultImplementation = 'RtLopez\\DecimalBCMath';
   private static $defaultPrecision = 2;
+  private static $defaultDecPoint = '.';
+  private static $defaultThousandsSep = ' ';
   
   /**
    * @var mixed internal value
@@ -88,6 +90,22 @@ abstract class Decimal
   {
     return self::$defaultPrecision;
   }
+  
+  public static function setDefaultDecimalPoint($dec_point) {
+    self::$defaultDecPoint = $dec_point;
+  }
+  
+  public static function getDefaultDecimalPoint() {
+    return self::$defaultDecPoint;
+  }
+  
+  public static function setDefaultThousandsSeparator($thousands_sep) {
+    self::$defaultThousandsSep = $thousands_sep;
+  }
+  
+  public static function getDefaultThousandsSeparator() {
+    return self::$defaultThousandsSep;
+  }
 
   /**
    * convert object to string
@@ -97,8 +115,16 @@ abstract class Decimal
     return $this->toString();
   }
   
-  public function format($prec = null, $dec_point = '.' , $thousands_sep = ' ', $trailing_zero = true)
+  public function format($prec = null, $dec_point = null , $thousands_sep = null, $trailing_zero = true)
   {
+    if ($dec_point === null) {
+        $dec_point = self::getDefaultDecimalPoint();
+    }
+    
+    if ($thousands_sep === null) {
+        $thousands_sep = self::getDefaultThousandsSeparator();
+    }
+      
     $prec = $prec !== null ? $prec : $this->prec;
     $str = $this->round($prec)->toString();
     
@@ -134,7 +160,7 @@ abstract class Decimal
     }
     
     // connect all parts
-    $number = $sign . trim($int_str . $dec_point . $dec_str);
+    $number = $sign . trim($int_str . $dec_point . $dec_str, " $dec_point$thousands_sep");
     if($trailing_zero) return $number;
     
     return $this->_trim($number);

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -109,6 +109,15 @@ class FormateTest extends \PHPUnit_Framework_TestCase
     $res = new $class('1234.5678', 4);
     $this->assertEquals('1,234.5678', $res->format(null, '.', ','));
   }
+  
+  /**
+   * @dataProvider providerClasses
+   */
+  public function testFormatWithoutCommaThousands($class)
+  {
+    $res = new $class('234.5678', 4);
+    $this->assertEquals('234.5678', $res->format(null, '.', ','));
+  }
 
   /**
    * @dataProvider providerClasses


### PR DESCRIPTION
Fix format bug when using thousands separator other than spaces and when formatting with zero digits in decimal part.

E.g.: 
```php
$value = \RtLopez\Decimal::create('135.825', 3);
echo $value->format(0, ",", ".");

Before fix:
Expected: "135"
Actual: ".135,"

After fix:
Actual: "135"
```

Also provides an way for defining default thousands separator and decimal point, without breaking backwards compatibility. 